### PR TITLE
Half Float Textures: Fixed behavior of Float32 and Float16 array type support logic for both WebGL 1 and 2 APIs

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -142,4 +142,4 @@ function getOS() {
   return os;
 }
 
-export {hex2rgba, rgba2hex, hex2rgb, rgb2hex, rgb2hsv, hsv2rgb, zip, getMinZoom};
+export {hex2rgba, rgba2hex, hex2rgb, rgb2hex, rgb2hsv, hsv2rgb, zip, getMinZoom, getOS};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,7 +121,7 @@ function* zip(...args: any[]) {
 
 function getOS() {
   var userAgent = window.navigator.userAgent,
-      platform = window.navigator?.userAgentData?.platform || window.navigator.platform,
+      platform = window.navigator.platform,
       macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'],
       windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'],
       iosPlatforms = ['iPhone', 'iPad', 'iPod'],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -119,4 +119,27 @@ function* zip(...args: any[]) {
 	}
 }
 
+function getOS() {
+  var userAgent = window.navigator.userAgent,
+      platform = window.navigator?.userAgentData?.platform || window.navigator.platform,
+      macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'],
+      windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'],
+      iosPlatforms = ['iPhone', 'iPad', 'iPod'],
+      os = null;
+
+  if ((macosPlatforms.indexOf(platform) !== -1) && (navigator.maxTouchPoints <= 1)) {
+    os = 'Mac OS';
+  } else if ((iosPlatforms.indexOf(platform) !== -1)  || ( (macosPlatforms.indexOf(platform) !== -1)  && (navigator.maxTouchPoints > 1))) { 
+    os = 'iOS';
+  } else if (windowsPlatforms.indexOf(platform) !== -1) {
+    os = 'Windows';
+  } else if (/Android/.test(userAgent)) {
+    os = 'Android';
+  } else if (/Linux/.test(platform)) {
+    os = 'Linux';
+  }
+
+  return os;
+}
+
 export {hex2rgba, rgba2hex, hex2rgb, rgb2hex, rgb2hsv, hsv2rgb, zip, getMinZoom};


### PR DESCRIPTION
This was a bit of a beast to figure out, but I feel mostly confident it works. 

The crux of the issue came down to WebGL 1 vs WebGL2 behavior. If in a WebGL1 rendering context, then loading these extensions (I corrected the half-float one) is a reasonable way to check for support, since Safari/WebKit returns null for OES_texture_float_linear on iOS and iPadOS. However, in WebGL2, many of these extensions were baselined into the standard. This means getExtension returns null, and all extension checks are only valid in the case of WebGL 1. Unfortunately, safari lies to the API and says it supports float textures, so the only way I knew how to fix it was to do an OS check. This OS check also works in the case a client has "request desktop website" enabled, so that it gracefully fails as intended. 