### PR TITLE
Fix contour labels with longitude > 180 not showing up

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "autumnplot-gl",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "description": "",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/public/main.js
+++ b/public/main.js
@@ -166,15 +166,19 @@ async function makeGFSLayers() {
     }
 
     const t2m_field = new apgl.RawScalarField(grid_gfs, t2m_data_pad);
-    const t2m_contour = new apgl.ContourFill(t2m_field, {'cmap': colormap});
-    const t2m_layer = new apgl.PlotLayer('nh_probs', t2m_contour);
+    const t2m_fill = new apgl.ContourFill(t2m_field, {'cmap': colormap});
+    const t2m_filllayer = new apgl.PlotLayer('t2m_fill', t2m_fill);
 
+    const t2m_contour = new apgl.Contour(t2m_field, {levels: [32], line_width: 4});
+    const t2m_contourlayer = new apgl.PlotLayer('t2m_contour', t2m_contour);
+    const labels = new apgl.ContourLabels(t2m_contour, {text_color: '#ffffff', halo: true, font_url_template: 'https://autumnsky.us/glyphs/{fontstack}/{range}.pbf'});
+    const label_layer = new apgl.PlotLayer('label', labels);
 
     const svg = apgl.makeColorBar(colormap, {label: "Temperature", fontface: 'Trebuchet MS', 
                                              ticks: [-60, -50, -40, -30, -20, -10, 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120],
                                              orientation: 'horizontal', tick_direction: 'bottom'});
 
-    return {layers: [t2m_layer], colorbar: [svg]};
+    return {layers: [t2m_filllayer, t2m_contourlayer, label_layer], colorbar: [svg]};
 }
 
 function makeHodoLayers() {

--- a/src/Grid.ts
+++ b/src/Grid.ts
@@ -711,7 +711,8 @@ class UnstructuredGrid extends Grid {
                 }
             }
 
-            recursiveThin(0.5, 0.5, 0);
+            // Start at -1 zoom depth, which should handle longitudes > 180 degrees.
+            recursiveThin(0.5, 0.5, -1);
 
             return new Uint8Array(kd_nodes.map(n => n.min_zoom));
         });


### PR DESCRIPTION
What it says.

It turned out that the recursive thinning algorithm that assigns min zoom levels on an unstructured grid wasn't visiting anywhere with longitude > 180 degrees. So those labels were assigned `MAP_MAX_ZOOM` as their minimum zoom level (i.e., never visible). So the fix is to start the recursion at level -1 instead of level 0. This visits everywhere in a 2x2 grid (instead of a 1x1 grid that the canonical globe is on), which covers the case in which longitudes are > 180 degrees.

Fixes #17.